### PR TITLE
Unitary Hack -Issiue#4-Fix data type exceptions by centralizing conversion in SpaceCurve

### DIFF
--- a/src/qurveros/optspacecurve.py
+++ b/src/qurveros/optspacecurve.py
@@ -312,16 +312,13 @@ class BarqCurve(OptimizableSpaceCurve):
                 raise ValueError('Inconsistent number of free points with'
                                  ' provided initial free points.')
 
-        if init_pgf_params is None:
-
-            init_pgf_params = barqtools.get_default_pgf_params_dict()
-
-        if init_prs_params is None:
-            init_prs_params = {}
-
-        params['free_points'] = init_free_points
-        params['pgf_params'] = init_pgf_params
-        params['prs_params'] = init_prs_params
+        # Set parameters (type conversion happens in parent's set_params)
+        
+        params.update({
+            'free_points': init_free_points,
+            'pgf_params': init_pgf_params or barqtools_get_deafult_pgf_params_dict(),
+            'prs_params': init_prs_params or {}
+        })
 
         return super().initialize_parameters(params)
 

--- a/src/qurveros/spacecurve.py
+++ b/src/qurveros/spacecurve.py
@@ -6,9 +6,12 @@ RobustnessProperties.
 import jax
 import jax.numpy as jnp
 import functools
+import numpy as np
+import warnings
 
 from qurveros.settings import settings
 from qurveros import controltools, frametools, beziertools, plottools
+from jax.config import config 
 
 
 class SpaceCurve:
@@ -133,7 +136,31 @@ class SpaceCurve:
         evaluated for the new set of auxiliary parameters.
         """
 
-        self.params = params
+        #Determine the correct float type based on JAX config
+        float_dtype= jnp.float64 if config.jax_enable_x64 else jnp.float32
+        
+        def convert_value(v):
+            
+            """Helper function that recursively convert values to JAX-compatible floats"""
+            if isinstance(v,(jnp.ndarray,np.ndarray)): 
+                if not jnp.issubdtype(v.dtype,jnp.floating):
+                    warnings.warn(f"Converting array to{float_dtype}")
+                    return jnp.asarray(v,dtype=float_dtype)
+                return v
+            elif isinstance(v,(list,tuple)):
+                return jnp.asarray(v,dtype=float_dtype)
+            elif isinstance(v,(int,float)):
+                warnings.warn(f"Converting scalar{v} to {float_dtype}")
+                return float_dtype.type(v)
+            elif isinstance(v,dict):
+                return {k:convert_value(v) for k,v in v.items()}
+            return v
+        
+        #Convert all parameters while preserving the original structure 
+        converted_params ={
+            k:convert_value(v) for k ,v in params.items()
+        }
+        self.params = converted_params
 
         self.frenet_dict = None
         self.control_dict = None


### PR DESCRIPTION
This PR addresses #4 and #8 by:
- Moving type conversion logic to `SpaceCurve.set_params()`.
- Handling float precision dynamically based on `jax_enable_x64`.
- Adding warnings for implicit conversions.

Changes:
- Updated `optspacecurve.py` to delegate type conversion to parent class.
- Enhanced `spacecurve.py` to handle arrays, scalars, and nested structures.
